### PR TITLE
Create missing install directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -284,6 +284,7 @@ dox doxygen:
 install-data-local:
 	$(mkinstalldirs) $(DESTDIR)$(prefix)
 	$(mkinstalldirs) $(DESTDIR)@confdir@
+	$(mkinstalldirs) $(DESTDIR)@fsconfdir@/autoload_configs
 	@[ -f "$(DESTDIR)@confdir@/freetdm.conf" ] || ( cp conf/*.conf $(DESTDIR)@confdir@)
 	@[ -f "$(DESTDIR)@fsconfdir@/autoload_configs/freetdm.conf.xml" ] || ( cp -f conf/freetdm.conf.xml $(DESTDIR)@fsconfdir@/autoload_configs)
 	@echo FreeTDM Installed


### PR DESCRIPTION
install-data-local doesn't create @fsconfdir@/autoload_configs. So if
freetdm.conf.xml doesn't exit there and it tries to copy the sample file
over, it fails.

cp: cannot create regular file '/somewhere/etc/freeswitch/autoload_configs': No such file or directory

This adds the missing line to the Makefile.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>