### PR TITLE
Revert changes to ftdm_set_string, closes #7

### DIFF
--- a/src/include/ftdm_os.h
+++ b/src/include/ftdm_os.h
@@ -67,8 +67,7 @@ typedef uint64_t ftdm_time_t;
 #define ftdm_copy_string(x,y,z) strncpy(x, y, z - 1)
 
 /*! \brief strncpy into a fixed-length buffer */
-/* #define ftdm_set_string(x,y) strncpy(x, y, sizeof(x)-1) */
-#define ftdm_set_string(x,y) {memcpy(x, y, (sizeof(x)>sizeof(y)?sizeof(y):sizeof(x))-1); x[(sizeof(x)>sizeof(y)?sizeof(y):sizeof(x))-1] = 0;}
+#define ftdm_set_string(x,y) strncpy(x, y, sizeof(x)-1)
 
 /*! \brief check for null or zero length string buffer */
 #define ftdm_strlen_zero(s) (!s || *s == '\0')

--- a/src/include/private/ftdm_core.h
+++ b/src/include/private/ftdm_core.h
@@ -132,8 +132,7 @@ extern "C" {
 #define GOTO_STATUS(label,st) status = st; goto label ;
 
 #define ftdm_copy_string(x,y,z) strncpy(x, y, z - 1) 
-/* #define ftdm_set_string(x,y) strncpy(x, y, sizeof(x)-1) */
-#define ftdm_set_string(x,y) {memcpy(x, y, (sizeof(x)>sizeof(y)?sizeof(y):sizeof(x))-1); x[(sizeof(x)>sizeof(y)?sizeof(y):sizeof(x))-1] = 0;}
+#define ftdm_set_string(x,y) strncpy(x, y, sizeof(x)-1)
 #define ftdm_strlen_zero(s) (!s || *s == '\0')
 #define ftdm_strlen_zero_buf(s) (*s == '\0')
 


### PR DESCRIPTION
By doing a memcpy and using sizeof of the smaller argument, if the source argument is a pointer, on 64bits arches the sizeof(y) will be 8, which results in truncating the copied string to 8 chars.

This wil address https://github.com/freeswitch/freetdm/issues/7